### PR TITLE
Prism/babel

### DIFF
--- a/packages/web/.babelrc
+++ b/packages/web/.babelrc
@@ -1,4 +1,15 @@
 {
   "presets": ["next/babel", "@zeit/next-typescript/babel"],
-  "plugins": ["styled-components"]
+  "plugins": [
+    "styled-components",
+    [
+      "prismjs",
+      {
+        "languages": ["javascript", "css", "markup", "typescript"],
+        "plugins": ["line-numbers"],
+        "theme": "solarizedlight",
+        "css": true
+      }
+    ]
+  ]
 }

--- a/packages/web/.babelrc
+++ b/packages/web/.babelrc
@@ -5,7 +5,14 @@
     [
       "prismjs",
       {
-        "languages": ["javascript", "css", "markup", "typescript"],
+        "languages": [
+          "javascript",
+          "css",
+          "markup",
+          "typescript",
+          "json",
+          "markdown"
+        ],
         "plugins": ["line-numbers"],
         "theme": "solarizedlight",
         "css": true

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -51,7 +51,7 @@ export const CodeFile: React.SFC<Props> = ({
     <CreateCodeReviewQuestionComponent>
       {mutate => (
         <>
-          <pre className={`line-numbers language-typescript`}>
+          <pre className={`line-numbers language-${extension}`}>
             <code>{code}</code>
           </pre>
           {/* <pre className={`line-numbers`}>

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -1,17 +1,23 @@
-import Highlight, { defaultProps } from "prism-react-renderer";
-import * as Prism from "prismjs";
-import "prismjs/themes/prism.css";
-import "prismjs/themes/prism-solarizedlight.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.js";
+//import Highlight, { defaultProps } from 'prism-react-renderer';
+import * as Prism from 'prismjs';
+
+//********************************* */
+// to import a specific language
+//import 'prismjs/components/prism-typescript';
+//********************************* */
+
+//import 'prismjs/themes/prism.css';
+//import 'prismjs/themes/prism-solarizedlight.css';
+//import 'prismjs/plugins/line-numbers/prism-line-numbers.css';
+//import 'prismjs/plugins/line-numbers/prism-line-numbers.js';
 
 import {
   CreateCodeReviewQuestionComponent,
   FindCodeReviewQuestionsComponent
-} from "./apollo-components";
-import { QuestionReply } from "./QuestionReply";
-import { useInputValue } from "../utils/useInputValue";
-import { useEffect } from "react";
+} from './apollo-components';
+import { QuestionReply } from './QuestionReply';
+import { useInputValue } from '../utils/useInputValue';
+import { useEffect } from 'react';
 
 interface Props {
   code: string | null;
@@ -28,33 +34,36 @@ export const CodeFile: React.SFC<Props> = ({
   username,
   repo
 }) => {
-  const [startingLineNum, startingLineNumChange] = useInputValue("0");
-  const [endingLineNum, endingLineNumChange] = useInputValue("0");
-  const [text, textChange] = useInputValue("");
+  const [startingLineNum, startingLineNumChange] = useInputValue('0');
+  const [endingLineNum, endingLineNumChange] = useInputValue('0');
+  const [text, textChange] = useInputValue('');
 
   useEffect(() => {
-    // Prism.highlightAll();
+    Prism.highlightAll();
     return () => {};
-  });
+  }, []);
 
-  const extension = path ? path.split(".").pop() : "";
+  const extension = path ? path.split('.').pop() : '';
 
-  console.log(defaultProps);
+  //console.log(defaultProps);
 
   return (
     <CreateCodeReviewQuestionComponent>
       {mutate => (
         <>
+          <pre className={`line-numbers language-typescript`}>
+            <code>{code}</code>
+          </pre>
           {/* <pre className={`line-numbers`}>
             <code className={`language-${extension}`}>
-              {(code || "").split("\n").map((token, i) => (
+              {(code || '').split('\n').map((token, i) => (
                 <div key={i} className="token-line">
                   {token}
                 </div>
               ))}
             </code>
           </pre> */}
-          <Highlight
+          {/* <Highlight
             {...defaultProps}
             theme={undefined}
             code={code}
@@ -84,7 +93,7 @@ export const CodeFile: React.SFC<Props> = ({
                 ))}
               </pre>
             )}
-          </Highlight>
+          </Highlight> */}
           <form
             onSubmit={async e => {
               e.preventDefault();
@@ -145,7 +154,7 @@ export const CodeFile: React.SFC<Props> = ({
                       <div>|{crq.creator.username}|</div>
                       <div>{crq.text}</div>
                       {crq.replies.map(reply => (
-                        <div key={reply.id} style={{ color: "pink" }}>
+                        <div key={reply.id} style={{ color: 'pink' }}>
                           <div>${reply.creator.username}$</div>
                           {reply.text}
                         </div>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,6 +16,7 @@
     "@octokit/rest": "16.2.0",
     "apollo-boost": "0.1.22",
     "apollo-link-context": "1.0.10",
+    "babel-plugin-prismjs": "^1.0.2",
     "cookie": "0.3.1",
     "downshift": "3.1.6",
     "formik": "1.4.0",


### PR DESCRIPTION
I saw your last video and i could not go to sleep before solving it :(
It had to be something simple.

Well after to much head butting, the only thing that i can see as the responsible is the bundling. Prism must 'require' dynamically the files for the language: https://github.com/PrismJS/prism/blob/master/components/index.js#L48-L61
But Babel transpile all required files and webpack bundle them in server side...

The syntax works if one imports them directly. I left a commented example in the PR. The 'import 'prismjs/components/prism-typescript';' part.

I ended trying https://github.com/mAAdhaTTah/babel-plugin-prismjs that the Prism site mentions and it worked very well. i just had to add the config with the languages, theme, plugins, etc in the .babelrc file

Not the best solution but i can go to sleep now :)