### PR TITLE
monaco jsx partial

### DIFF
--- a/packages/web/components/MonacoCodeFile.tsx
+++ b/packages/web/components/MonacoCodeFile.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic"
 import { useState } from "react"
 import MonacoEditor from "react-monaco-editor"
+import * as monacoEditorOrig from "monaco-editor/esm/vs/editor/editor.api"
 import { filenameToLang } from "../utils/filenameToLang"
 
 const MyMonacoEditor = dynamic(import("react-monaco-editor") as any, {
@@ -30,10 +31,41 @@ export const MonacoCodeFile: React.SFC<Props> = ({ code, path }) => {
         selectOnLineNumbers: true,
         readOnly: true,
       }}
-      editorWillMount={monaco => {
-        monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
-          jsx: 2,
+      editorWillMount={(monaco: typeof monacoEditorOrig) => {
+        /* 
+        Taken from https://github.com/supnate/rekit/blob/master/packages/rekit-studio/src/features/editor/configMonaco.js
+        and further references at https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-configure-javascript-defaults
+         */
+        const compilerDefaults = {
+          jsxFactory: "React.createElement",
+          reactNamespace: "React",
+          jsx: monaco.languages.typescript.JsxEmit.React,
+          target: monaco.languages.typescript.ScriptTarget.ES2016,
+          allowNonTsExtensions: true,
+          moduleResolution:
+            monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+          experimentalDecorators: true,
+          noEmit: true,
+          allowJs: true,
+          typeRoots: ["node_modules/@types"],
+        }
+        monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+          compilerDefaults
+        )
+        monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
+          compilerDefaults
+        )
+        monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+          noSemanticValidation: true,
+          noSyntaxValidation: false,
         })
+        monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+          noSemanticValidation: true,
+          noSyntaxValidation: false,
+        })
+        monaco.Uri.parse("file:///main.tsx")
+        /* monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true)
+        monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true) */
       }}
     />
   )


### PR DESCRIPTION
I took a look at jsx syntax highlight and got what i consider a partial success by finishing your last reasoning on the video. 
I still don't like the results but it's somewhat better.
I believe that most of the options that i added are not really necessary for a read only file. I tried commenting some of them and it wasn't relevant for the syntax.

A personal banter: 
- I must say that the experience was valuable but i ended being not very convinced with monaco code as just a simple syntax highlighter. I much prefer prism. There are many more language integration and it seem much lighter.
- The worst thing that i don't like in prism is their themes, but it is easily fixed with some edit of one of the theme.
- One thing that i like in monaco is the ability to select the code with the mouse. Much easier to add code reviews than using inputs. But it can also be achieved easily with prism with some more code.
- Monaco bring the added power to add edit in the future, if one so desire. But all in all and given the structure of the codeponder project, a future migration from prism to Monaco should bring that great a difficulty.