### PR TITLE
Use generics to give types to dynamic components

### DIFF
--- a/packages/web/components/MonacoCodeFile.tsx
+++ b/packages/web/components/MonacoCodeFile.tsx
@@ -1,11 +1,11 @@
 import dynamic from "next/dynamic"
 import { useState } from "react"
-import MonacoEditor from "react-monaco-editor"
+import { MonacoEditorProps } from "react-monaco-editor"
 import { filenameToLang } from "../utils/filenameToLang"
 
-const MyMonacoEditor = dynamic(import("react-monaco-editor") as any, {
+const MyMonacoEditor = dynamic<MonacoEditorProps>(import("react-monaco-editor") as any, {
   ssr: false,
-}) as typeof MonacoEditor
+});
 
 interface Props {
   code: string | null


### PR DESCRIPTION
Much cleaner way of doing this. Basically `dynamic` accepts a generic for props of the component. 


```ts
const MyComponent = dynamic<Props>(import("path/to/component"), { ssr: false });
```