### PR TITLE
Add and import empty css file  because nextjs router bug

### DIFF
--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -6,6 +6,8 @@ import { ApolloProvider } from "react-apollo";
 import withApolloClient from "../lib/with-apollo-client";
 import { GitHubApolloClientContext } from "../components/GithubApolloClientContext";
 
+import "../empty.css";
+
 class MyApp extends App {
   componentDidCatch(error: any, errorInfo: any) {
     console.log("err");


### PR DESCRIPTION
That was a very weird bug.
I found a discussion about it here
https://github.com/zeit/next-plugins/issues/282

I tried the simplest of the solutions indicated there and it worked.
p.s. I put the css file in the root of the web folder, but if it is to be used, maybe one should put it in the packages\web\.next\static\css directory?
