### PR TITLE
add event listener to line numbers

### DIFF
--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -3,8 +3,8 @@ import * as Prism from "prismjs";
 import { Spinner } from "@codeponder/ui";
 import "prismjs/themes/prism.css";
 import "prismjs/themes/prism-coy.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.js";
+import "./../lib/line-numbers/prism-line-numbers.css";
+import "./../lib/line-numbers/prism-line-numbers.js";
 import "prismjs/plugins/line-highlight/prism-line-highlight.css";
 import "prismjs/plugins/line-highlight/prism-line-highlight.js";
 
@@ -57,7 +57,19 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
                       try {
                         await loadLanguage(lang);
                       } catch {}
+
+                      /***************************************************
+                       * Pass the callback to get access to the event
+                       ****************************************************/
+                      Prism.plugins.lineNumbers.setCallback((event: any) => {
+                        console.log(
+                          "codeFile callback: ",
+                          event.target.innerHTML
+                        );
+                      });
+
                       Prism.highlightAll();
+
                       hasLoadedLanguage.current = true;
                     }
                   }}

--- a/packages/web/lib/line-numbers/prism-line-numbers.css
+++ b/packages/web/lib/line-numbers/prism-line-numbers.css
@@ -1,0 +1,49 @@
+pre[class*="language-"].line-numbers {
+  position: relative;
+  padding-left: 3.8em;
+  /* disable all css counters */
+  /* counter-reset: linenumber; */
+}
+
+pre[class*="language-"].line-numbers > code {
+  position: relative;
+  white-space: inherit;
+}
+
+.line-numbers .line-numbers-rows {
+  position: absolute;
+  /* pointer-event: none in the original 
+	 blocking event listeners
+  */
+  pointer-events: auto;
+  top: 0;
+  font-size: 100%;
+  left: -3.8em;
+  width: 3em; /* works for line-numbers below 1000 lines */
+  letter-spacing: -1px;
+  border-right: 1px solid #999;
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.line-numbers-rows > span {
+  /* pointer-event: none in the original 
+     blocking event listeners
+  */
+  pointer-events: auto;
+  display: block;
+  /* disable all css counters */
+  /* counter-increment: linenumber; */
+}
+
+.line-numbers-rows > span:before {
+  /* disable all css counters */
+  /* content: counter(linenumber); */
+  color: #999;
+  display: block;
+  padding-right: 0.8em;
+  text-align: right;
+}

--- a/packages/web/lib/line-numbers/prism-line-numbers.js
+++ b/packages/web/lib/line-numbers/prism-line-numbers.js
@@ -1,0 +1,206 @@
+(function() {
+  /* the env arg has 
+		
+		-- code original in string format
+		env.code					: any
+		-- the <code/> HtmlElement
+		env.element					: HtmlElement | undefined
+		-- The language in string format
+		env.language				: Prism.LanguageDefinition | undefined
+		-- was undefined in the console
+		env.grammar					: 
+		
+
+		---- these do not appear on the console of the plugin
+		---- but are in the interface?
+		env.attributes				: any
+		env.classes					: string[] | undefined			
+		env.content					: string | undefined
+		env.highlightedCode			: any
+		env.parent					: HtmlElement
+		env.tag						: string | undefined
+		env.type					: string | undefined
+
+		---- line number plugin adds one more in the file
+		---- probably to register itself with prism
+		env.plugins
+	 */
+
+  if (typeof self === "undefined" || !self.Prism || !self.document) {
+    return;
+  }
+
+  /**
+   * Plugin name which is used as a class name for <pre> which is activating the plugin
+   * @type {String}
+   */
+  var PLUGIN_NAME = "line-numbers";
+
+  /**
+   * Regular expression used for determining line breaks
+   * @type {RegExp}
+   */
+  var NEW_LINE_EXP = /\n(?!$)/g;
+
+  /**
+   * Resizes line numbers spans according to height of line of code
+   * @param {Element} element <pre> element
+   */
+  var _resizeElement = function(element) {
+    var codeStyles = getStyles(element);
+    var whiteSpace = codeStyles["white-space"];
+
+    if (whiteSpace === "pre-wrap" || whiteSpace === "pre-line") {
+      var codeElement = element.querySelector("code");
+      var lineNumbersWrapper = element.querySelector(".line-numbers-rows");
+      var lineNumberSizer = element.querySelector(".line-numbers-sizer");
+      var codeLines = codeElement.textContent.split(NEW_LINE_EXP);
+
+      if (!lineNumberSizer) {
+        lineNumberSizer = document.createElement("span");
+        lineNumberSizer.className = "line-numbers-sizer";
+
+        codeElement.appendChild(lineNumberSizer);
+      }
+
+      lineNumberSizer.style.display = "block";
+
+      codeLines.forEach(function(line, lineNumber) {
+        lineNumberSizer.textContent = line || "\n";
+        var lineSize = lineNumberSizer.getBoundingClientRect().height;
+        lineNumbersWrapper.children[lineNumber].style.height = lineSize + "px";
+      });
+
+      lineNumberSizer.textContent = "";
+      lineNumberSizer.style.display = "none";
+    }
+  };
+
+  /**
+   * Returns style declarations for the element
+   * @param {Element} element
+   */
+  var getStyles = function(element) {
+    if (!element) {
+      return null;
+    }
+
+    return window.getComputedStyle
+      ? getComputedStyle(element)
+      : element.currentStyle || null;
+  };
+
+  window.addEventListener("resize", function() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll("pre." + PLUGIN_NAME),
+      _resizeElement
+    );
+  });
+
+  Prism.hooks.add("complete", function(env) {
+    /**********************************
+     * Some initial tests
+     **********************************/
+
+    // if no code then ignore
+    if (!env.code) {
+      return;
+    }
+    //console.log("env: ", env);
+
+    // works only for <code> wrapped inside <pre> (not inline)
+    var pre = env.element.parentNode;
+    var clsReg = /\s*\bline-numbers\b\s*/;
+    if (
+      !pre ||
+      !/pre/i.test(pre.nodeName) ||
+      // Abort only if nor the <pre> nor the <code> have the class
+      (!clsReg.test(pre.className) && !clsReg.test(env.element.className))
+    ) {
+      return;
+    }
+
+    if (env.element.querySelector(".line-numbers-rows")) {
+      // Abort if line numbers already exists
+      return;
+    }
+
+    if (clsReg.test(env.element.className)) {
+      // Remove the class 'line-numbers' from the <code>
+      env.element.className = env.element.className.replace(clsReg, " ");
+    }
+    if (!clsReg.test(pre.className)) {
+      // Add the class 'line-numbers' to the <pre>
+      pre.className += " line-numbers";
+    }
+
+    /*******************************************
+     * Beginning of the logic
+     ********************************************/
+
+    /* discover how many lines of code there is */
+    var match = env.code.match(NEW_LINE_EXP);
+    var linesNum = match ? match.length + 1 : 1;
+
+    /* lineNumbersWrapper will be the parent span of the line numbers
+     * (span.line-numbers-rows)
+     */
+    var lineNumbersWrapper = document.createElement("span");
+    lineNumbersWrapper.setAttribute("aria-hidden", "true");
+    lineNumbersWrapper.className = "line-numbers-rows";
+
+    /* ********************************************************
+     * The span containing the line numbers are created here
+     **********************************************************/
+
+    for (var i = 0; i < linesNum; i++) {
+      var line = document.createElement("span");
+      line.innerHTML = i;
+      // add the evenntlistener to each line number spans
+      // TODO: consider adding the event listener only to the parent
+      // and getting the child clicked from it
+      // this way there will be only an event listener
+      // instead of n for n lines of code
+      line.onclick = function(event) {
+        event.stopPropagation();
+        // pass the event to a callback
+        Prism.plugins.lineNumbers.eventCallback(event);
+      };
+      // append the line numbers (span) to the parent (span.line-numbers-rows)
+      lineNumbersWrapper.appendChild(line);
+    }
+
+    // append the parent span to the code htmlElement
+    env.element.appendChild(lineNumbersWrapper);
+
+    _resizeElement(pre);
+
+    // run itself...
+    Prism.hooks.run("line-numbers", env);
+  });
+
+  // registers itsel with prism hooks
+  Prism.hooks.add("line-numbers", function(env) {
+    env.plugins = env.plugins || {};
+    env.plugins.lineNumbers = true;
+  });
+
+  /**
+   * Global exports
+   */
+  Prism.plugins.lineNumbers = {
+    /*
+     * 	quick and dirty solution
+     *
+     *   i also deleted its original property
+     *   since it wasn't necessary for this application
+     */
+    localCallback: () => {},
+    setCallback: callback => {
+      this.localCallback = callback;
+    },
+    eventCallback: event => {
+      return this.localCallback(event);
+    },
+  };
+})();

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,10 +43,6 @@
     "graphql-codegen-typescript-client": "0.15.1",
     "graphql-codegen-typescript-common": "0.15.1",
     "graphql-codegen-typescript-react-apollo": "0.15.1",
-<<<<<<< HEAD
-=======
-    "next-plugin-styled-icons": "5.2.0",
->>>>>>> ac6662e0c6db453f3a694979ea1f2215158482c0
     "nodemon": "1.18.9",
     "ts-node": "7.0.1",
     "tslint": "5.12.0",


### PR DESCRIPTION
I tried to use the line number plugin, but it was a real uphill battle and with no trophy at the end.
The line number plugin has some serious problems.
- It puts _pointer-event: none_ in the several places in the css which disable the event listeners. One has to override it.
- The worst is that the numbers are using the _CSS counter_. From what i understand, it is apparently impossible to get its value. The best that could be achieved, would be to iterate over the spans to try to find its position in the _DOM collection_ or _NodeList_. Difficult....

The easiest solution that i could find to solve all of this is to copy the plugin to _packages\web\lib\_ and override the code.

I put some heavy and ugly comments (wanting to be deleted) to structure a little bit the code and quicken the access to it for anyone who comes for the first time.

In the end it is relatively simple to work with it. The most important part is the **env.element** arg. It is a _HtmlElement_ for the "_code tag_", so it can be directly manipulated and accessed.

I also put a quick an dirty callback system, to access the click event on the _codeFile.tsx_. I didn't want to waist to much time restructuring the code in the _prism-line-numbers.js file_.

The css should be twicked a little more :)

All in all, the code is absolutely ugly and not in Ts, but it should give the beginning of a solution or at least some ideas...
