### PR TITLE
added Prism React Renderer for syntax highlighting

### DIFF
--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 //import * as Prism from "prismjs";
 //import "prismjs/themes/prism.css";
 import "prismjs/themes/prism-coy.css";
@@ -64,12 +64,14 @@ const SelectLinesMouse = (arg: number[]) => {
 };
 
 export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
+  // does this needs so many states? Should be simplified more...
   const [lineSelectionState, setLineSelectionState] = useState<number[]>([
     0,
     0,
   ]);
   const [startLinesSelection, setStartLinesSelection] = useState<number>(0);
   const [endLinesSelection, setEndLinesSelection] = useState<number>(0);
+
   const lang: Language = path ? filenameToLang(path) : "";
   const variables = {
     path,
@@ -112,21 +114,36 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
   };
 
   /*
-   * handleStartLinesSelection and handleEndLinesSelection are temporary solutions
-   * They are still buggy
-   * TODO: add a 'debounceTime' to the inputs values for an easier UX experience
-   * it should be easy to do it or maybe just use something like
-   * https://www.npmjs.com/package/react-debounce-input or
-   * https://lodash.com/docs/#debounce (used by the above ref)
+   * handleStartLinesSelection and handleEndLinesSelection
+   * are still a little buggy, but almost there
+   * TODO: merge the 2 functions to avoid repetition
+   * TODO: better handling of the situation when values of input1 > input2
+   * TODO: ability to reset the line selections directly from the input
    */
   const handleStartLinesSelection = (event: any) => {
-    setLineSelectionState([event.currentTarget.value, lineSelectionState[1]]);
-    setStartLinesSelection(event.currentTarget.value);
+    if (event.target) {
+      // || lineSelectionState[0] to block NaN and secure default
+      // TODO: add a better checks
+      let value1 = parseInt(event.target.value, 10) || lineSelectionState[0];
+      let value2 = lineSelectionState[1];
+      if (value1 > value2) {
+        value2 = value1;
+      }
+      setLineSelectionState([value1, value2]);
+      setStartLinesSelection(value1);
+      setEndLinesSelection(value2);
+    }
   };
 
   const handleEndLinesSelection = (event: any) => {
-    setLineSelectionState([lineSelectionState[0], event.currentTarget.value]);
-    setEndLinesSelection(event.currentTarget.value);
+    if (event.target) {
+      // || lineSelectionState[0] to block NaN and secure default
+      // TODO: add a better checks
+      let value = parseInt(event.target.value, 10) || lineSelectionState[1];
+      value = value >= lineSelectionState[0] ? value : lineSelectionState[0];
+      setLineSelectionState([lineSelectionState[0], value]);
+      setEndLinesSelection(value);
+    }
   };
 
   return (

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -1,15 +1,13 @@
-import { useRef } from "react";
-import * as Prism from "prismjs";
+//import * as Prism from "prismjs";
 import "prismjs/themes/prism.css";
 import "prismjs/themes/prism-coy.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.css";
-import "prismjs/plugins/line-numbers/prism-line-numbers.js";
-import "prismjs/plugins/line-highlight/prism-line-highlight.css";
-import "prismjs/plugins/line-highlight/prism-line-highlight.js";
+
+import styled from "styled-components";
+import Highlight, { defaultProps, Language } from "prism-react-renderer";
+//import theme from "prism-react-renderer/themes/vsDarkPlus";
 
 import { FindCodeReviewQuestionsComponent } from "./apollo-components";
 import { filenameToLang } from "../utils/filenameToLang";
-import { loadLanguage } from "../utils/loadLanguage";
 import { QuestionSection } from "./QuestionSection";
 
 interface Props {
@@ -19,9 +17,25 @@ interface Props {
 }
 
 export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
-  const hasLoadedLanguage = useRef(false);
+  const Pre = styled.pre`
+    text-align: left;
+    margin: 1em 0;
+    padding: 0.5em;
 
-  const lang = path ? filenameToLang(path) : "";
+    & .token-line {
+      line-height: 1.3em;
+      height: 1.3em;
+    }
+  `;
+
+  const LineNo = styled.span`
+    display: inline-block;
+    width: 2em;
+    user-select: none;
+    opacity: 0.3;
+  `;
+
+  const lang: Language = path ? filenameToLang(path) : "";
   const variables = {
     path,
     postId,
@@ -40,21 +54,27 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
 
         return (
           <>
-            <pre
-              ref={async () => {
-                if (!hasLoadedLanguage.current) {
-                  try {
-                    await loadLanguage(lang);
-                  } catch {}
-                  Prism.highlightAll();
-                  hasLoadedLanguage.current = true;
-                }
-              }}
-              className="line-numbers"
-              data-line={dataLines.join(" ")}
+            <Highlight
+              {...defaultProps}
+              theme={undefined}
+              code={code}
+              language={lang}
             >
-              <code className={`language-${lang}`}>{code}</code>
-            </pre>
+              {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre className={className} style={style}>
+                  {tokens.map((line, i) => {
+                    return (
+                      <div {...getLineProps({ line, key: i })}>
+                        <LineNo>{i + 1}</LineNo>
+                        {line.map((token, key) => {
+                          return <span {...getTokenProps({ token, key })} />;
+                        })}
+                      </div>
+                    );
+                  })}
+                </pre>
+              )}
+            </Highlight>
             <QuestionSection
               variables={variables}
               code={code || ""}

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -1,5 +1,5 @@
 //import * as Prism from "prismjs";
-import "prismjs/themes/prism.css";
+//import "prismjs/themes/prism.css";
 import "prismjs/themes/prism-coy.css";
 
 import styled from "styled-components";
@@ -16,25 +16,29 @@ interface Props {
   postId: string;
 }
 
+const Pre = styled.pre`
+  text-align: left;
+  margin: 4em 0;
+  padding: 0.5em;
+
+  & .token-line {
+    line-height: 1.3em;
+    height: 1.3em;
+  }
+
+  & .token-line:nth-child(odd) {
+    background: #f3faff;
+  }
+`;
+
+const LineNo = styled.span`
+  display: inline-block;
+  width: 2em;
+  user-select: none;
+  opacity: 0.3;
+`;
+
 export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
-  const Pre = styled.pre`
-    text-align: left;
-    margin: 1em 0;
-    padding: 0.5em;
-
-    & .token-line {
-      line-height: 1.3em;
-      height: 1.3em;
-    }
-  `;
-
-  const LineNo = styled.span`
-    display: inline-block;
-    width: 2em;
-    user-select: none;
-    opacity: 0.3;
-  `;
-
   const lang: Language = path ? filenameToLang(path) : "";
   const variables = {
     path,
@@ -61,7 +65,7 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
               language={lang}
             >
               {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                <pre className={className} style={style}>
+                <Pre className={className} style={style}>
                   {tokens.map((line, i) => {
                     return (
                       <div {...getLineProps({ line, key: i })}>
@@ -72,7 +76,7 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
                       </div>
                     );
                   })}
-                </pre>
+                </Pre>
               )}
             </Highlight>
             <QuestionSection

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -71,16 +71,12 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
     postId,
   };
 
-  // Handler to manage the array of selected lines
+  /*
+   * Handler to manage the array of selected lines
+   * It simulates the github line number selection
+   *  */
   const handleSelectLine = (lineNumber: number) => {
-    const tempSelectionState = [...lineSelectionState];
-
-    if (tempSelectionState.length == 0) {
-      tempSelectionState.push(lineNumber);
-      tempSelectionState.sort((a, b) => a - b);
-      setLineSelectionState([...tempSelectionState]);
-      return;
-    }
+    let tempSelectionState = [...lineSelectionState];
 
     const lineExist = tempSelectionState
       .filter(value => {
@@ -88,26 +84,20 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
       })
       .sort((a, b) => a - b);
 
-    if (lineExist.length !== tempSelectionState.length) {
-      setLineSelectionState([...lineExist]);
-      return;
-    }
-
-    if (tempSelectionState.length == 2) {
-      tempSelectionState[1] = lineNumber;
-      tempSelectionState.sort((a, b) => a - b);
-      setLineSelectionState([...tempSelectionState]);
-      return;
-    }
-
-    if (tempSelectionState.length > 0 || tempSelectionState.length < 2) {
+    // so many if else are not so legible...
+    // a switch might be possible here, but does it bring more or less?
+    if (tempSelectionState.length == 0) {
       tempSelectionState.push(lineNumber);
-      tempSelectionState.sort((a, b) => a - b);
-      setLineSelectionState([...tempSelectionState]);
-      return;
+    } else if (lineExist.length !== tempSelectionState.length) {
+      tempSelectionState = [...lineExist];
+    } else if (tempSelectionState.length == 2) {
+      tempSelectionState[1] = lineNumber;
+    } else if (tempSelectionState.length > 0 || tempSelectionState.length < 2) {
+      // this is the same as the first condition, but the order is important...
+      tempSelectionState.push(lineNumber);
     }
 
-    // perhaps not really needed, but just for completeness sake...
+    // The react hook must be outside conditions?
     tempSelectionState.sort((a, b) => a - b);
     setLineSelectionState([...tempSelectionState]);
     return;

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -64,7 +64,10 @@ const SelectLinesMouse = (arg: number[]) => {
 };
 
 export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
-  const [lineSelectionState, setLineSelectionState] = useState<number[]>([]);
+  const [lineSelectionState, setLineSelectionState] = useState<number[]>([
+    0,
+    0,
+  ]);
   const lang: Language = path ? filenameToLang(path) : "";
   const variables = {
     path,
@@ -76,25 +79,28 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
    * It simulates the github line number selection
    *  */
   const handleSelectLine = (lineNumber: number) => {
-    let tempSelectionState = [...lineSelectionState];
+    let tempSelectionState = lineSelectionState.filter(value => {
+      return value !== 0;
+    });
 
-    const lineExist = tempSelectionState.filter(value => {
+    const withoutRepeatLines = tempSelectionState.filter(value => {
       return value !== lineNumber;
     });
 
-    // so many if else are not so legible...
+    // so many else/if are not so legible...
     // a switch might be possible here, but does it bring more or less?
     if (tempSelectionState.length == 0) {
-      tempSelectionState.push(lineNumber);
-    } else if (lineExist.length !== tempSelectionState.length) {
-      tempSelectionState = [...lineExist];
-    } else if (tempSelectionState.length == 2) {
+      tempSelectionState = [lineNumber, lineNumber];
+    } else if (withoutRepeatLines.length == 0) {
+      tempSelectionState = [0, 0];
+    } else if (tempSelectionState.length !== withoutRepeatLines.length) {
+      tempSelectionState = [withoutRepeatLines[0], withoutRepeatLines[0]];
+    } else if (
+      tempSelectionState.length == 2 ||
+      tempSelectionState.length == 1
+    ) {
       tempSelectionState[1] = lineNumber;
-    } else if (tempSelectionState.length > 0 || tempSelectionState.length < 2) {
-      // this is the same as the first condition, but the order is important...
-      tempSelectionState.push(lineNumber);
     }
-
     // The react hook must be outside conditions?
     tempSelectionState.sort((a, b) => a - b);
     setLineSelectionState([...tempSelectionState]);

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -78,11 +78,9 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
   const handleSelectLine = (lineNumber: number) => {
     let tempSelectionState = [...lineSelectionState];
 
-    const lineExist = tempSelectionState
-      .filter(value => {
-        return value !== lineNumber;
-      })
-      .sort((a, b) => a - b);
+    const lineExist = tempSelectionState.filter(value => {
+      return value !== lineNumber;
+    });
 
     // so many if else are not so legible...
     // a switch might be possible here, but does it bring more or less?

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -68,6 +68,8 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
     0,
     0,
   ]);
+  const [startLinesSelection, setStartLinesSelection] = useState<number>(0);
+  const [endLinesSelection, setEndLinesSelection] = useState<number>(0);
   const lang: Language = path ? filenameToLang(path) : "";
   const variables = {
     path,
@@ -103,8 +105,28 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
     }
     // The react hook must be outside conditions?
     tempSelectionState.sort((a, b) => a - b);
+    setStartLinesSelection(tempSelectionState[0] || 0);
+    setEndLinesSelection(tempSelectionState[1] || 0);
     setLineSelectionState([...tempSelectionState]);
     return;
+  };
+
+  /*
+   * handleStartLinesSelection and handleEndLinesSelection are temporary solutions
+   * They are still buggy
+   * TODO: add a 'debounceTime' to the inputs values for an easier UX experience
+   * it should be easy to do it or maybe just use something like
+   * https://www.npmjs.com/package/react-debounce-input or
+   * https://lodash.com/docs/#debounce (used by the above ref)
+   */
+  const handleStartLinesSelection = (event: any) => {
+    setLineSelectionState([event.currentTarget.value, lineSelectionState[1]]);
+    setStartLinesSelection(event.currentTarget.value);
+  };
+
+  const handleEndLinesSelection = (event: any) => {
+    setLineSelectionState([lineSelectionState[0], event.currentTarget.value]);
+    setEndLinesSelection(event.currentTarget.value);
   };
 
   return (
@@ -178,8 +200,11 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
               postId={postId}
               programmingLanguage={lang}
               path={path}
-              /* Added a props to pass the selected lines */
-              linesSelection={lineSelectionState}
+              /* Added a props to pass and handle the selected lines */
+              startLinesSelection={startLinesSelection}
+              endLinesSelection={endLinesSelection}
+              handleStartLinesSelection={handleStartLinesSelection}
+              handleEndLinesSelection={handleEndLinesSelection}
             />
           </>
         );

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -2,11 +2,14 @@
 //import "prismjs/themes/prism.css";
 import "prismjs/themes/prism-coy.css";
 
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import Highlight, { defaultProps, Language } from "prism-react-renderer";
 //import theme from "prism-react-renderer/themes/vsDarkPlus";
 
-import { FindCodeReviewQuestionsComponent } from "./apollo-components";
+import {
+  FindCodeReviewQuestionsComponent,
+  FindCodeReviewQuestionsQuery,
+} from "./apollo-components";
 import { filenameToLang } from "../utils/filenameToLang";
 import { QuestionSection } from "./QuestionSection";
 
@@ -16,27 +19,21 @@ interface Props {
   postId: string;
 }
 
-const Pre = styled.pre`
-  text-align: left;
-  margin: 4em 0;
-  padding: 0.5em;
+const SelectLines = (prop: FindCodeReviewQuestionsQuery) => {
+  const styles = prop.findCodeReviewQuestions.reduce((total, current) => {
+    return (total += `
+     & .token-line:nth-child(n+${current.startingLineNum}):nth-child(-n+${
+      current.endingLineNum
+    }) {
+      background-color: #ffffcc;
+    }
+     `);
+  }, "");
 
-  & .token-line {
-    line-height: 1.3em;
-    height: 1.3em;
-  }
-
-  & .token-line:nth-child(odd) {
-    background: #f3faff;
-  }
-`;
-
-const LineNo = styled.span`
-  display: inline-block;
-  width: 2em;
-  user-select: none;
-  opacity: 0.3;
-`;
+  return css`
+    ${styles}
+  `;
+};
 
 export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
   const lang: Language = path ? filenameToLang(path) : "";
@@ -52,9 +49,29 @@ export const CodeFile: React.SFC<Props> = ({ code, path, postId }) => {
           return null;
         }
 
-        const dataLines = data.findCodeReviewQuestions.map(q => {
-          return `${q.startingLineNum}-${q.endingLineNum}`;
-        });
+        const Pre = styled.pre`
+          text-align: left;
+          margin: 4em 0;
+          padding: 0.5em;
+
+          & .token-line {
+            line-height: 1.3em;
+            height: 1.3em;
+          }
+
+          & .token-line:nth-child(odd) {
+            background: #f3faff;
+          }
+
+          ${SelectLines(data)};
+        `;
+
+        const LineNo = styled.span`
+          display: inline-block;
+          width: 2em;
+          user-select: none;
+          opacity: 0.3;
+        `;
 
         return (
           <>

--- a/packages/web/components/QuestionForm.tsx
+++ b/packages/web/components/QuestionForm.tsx
@@ -27,8 +27,8 @@ export const QuestionForm = ({
     () => {
       // Used local constant
       // but the values may be passed directly with the || ?
-      const startLinesSelection = linesSelection[0] || 0;
-      const endLinesSelection = linesSelection[1] || 0;
+      const startLinesSelection = linesSelection ? linesSelection[0] || 0 : 0;
+      const endLinesSelection = linesSelection ? linesSelection[1] || 0 : 0;
 
       setStartingLineNum(startLinesSelection);
       setEndingLineNum(endLinesSelection);

--- a/packages/web/components/QuestionForm.tsx
+++ b/packages/web/components/QuestionForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useEffect } from "react";
+import { ChangeEvent } from "react";
 
 import { CreateCodeReviewQuestionComponent } from "./apollo-components";
 import { useInputValue } from "../utils/useInputValue";
@@ -9,7 +9,10 @@ export interface QuestionFormProps {
   path?: string;
   postId: string;
   programmingLanguage?: string;
-  linesSelection: number[];
+  startLinesSelection: number;
+  endLinesSelection: number;
+  handleStartLinesSelection: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleEndLinesSelection: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const QuestionForm = ({
@@ -17,24 +20,12 @@ export const QuestionForm = ({
   path,
   postId,
   programmingLanguage,
-  linesSelection,
+  startLinesSelection,
+  endLinesSelection,
+  handleStartLinesSelection,
+  handleEndLinesSelection,
 }: QuestionFormProps) => {
-  const [startingLineNum, setStartingLineNum] = useInputValue("0");
-  const [endingLineNum, setEndingLineNum] = useInputValue("0");
   const [text, textChange] = useInputValue("");
-
-  useEffect(
-    () => {
-      // the undefined check is probably no longer needed
-      // but an extra check, in this type of app, are never a negative thing?
-      const startLinesSelection = linesSelection ? linesSelection[0] || 0 : 0;
-      const endLinesSelection = linesSelection ? linesSelection[1] || 0 : 0;
-
-      setStartingLineNum(startLinesSelection);
-      setEndingLineNum(endLinesSelection);
-    },
-    [linesSelection]
-  );
 
   return (
     <CreateCodeReviewQuestionComponent>
@@ -42,8 +33,8 @@ export const QuestionForm = ({
         <form
           onSubmit={async e => {
             e.preventDefault();
-            const start = parseInt(startingLineNum, 10);
-            const end = parseInt(endingLineNum, 10);
+            const start = startLinesSelection;
+            const end = endLinesSelection;
             const response = await mutate({
               variables: {
                 codeReviewQuestion: {
@@ -69,14 +60,14 @@ export const QuestionForm = ({
           <input
             name="startingLineNum"
             placeholder="startingLineNum"
-            value={startingLineNum}
-            onChange={setStartingLineNum}
+            value={startLinesSelection.toString()}
+            onChange={handleStartLinesSelection}
           />
           <input
             name="endingLineNum"
             placeholder="endingLineNum"
-            value={endingLineNum}
-            onChange={setEndingLineNum}
+            value={endLinesSelection.toString()}
+            onChange={handleEndLinesSelection}
           />
           <input
             name="question"

--- a/packages/web/components/QuestionForm.tsx
+++ b/packages/web/components/QuestionForm.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { ChangeEvent } from "react";
 
+import { DebounceInput } from "react-debounce-input";
+
 import { CreateCodeReviewQuestionComponent } from "./apollo-components";
 import { useInputValue } from "../utils/useInputValue";
 
@@ -57,16 +59,19 @@ export const QuestionForm = ({
             //console.log(response);
           }}
         >
-          <input
+          {/* see https://www.npmjs.com/package/react-debounce-input */}
+          <DebounceInput
             name="startingLineNum"
-            placeholder="startingLineNum"
-            value={startLinesSelection.toString()}
+            placeholder="0"
+            value={startLinesSelection}
+            debounceTimeout={300}
             onChange={handleStartLinesSelection}
           />
-          <input
+          <DebounceInput
             name="endingLineNum"
-            placeholder="endingLineNum"
-            value={endLinesSelection.toString()}
+            placeholder="0"
+            value={endLinesSelection}
+            debounceTimeout={300}
             onChange={handleEndLinesSelection}
           />
           <input

--- a/packages/web/components/QuestionForm.tsx
+++ b/packages/web/components/QuestionForm.tsx
@@ -25,8 +25,8 @@ export const QuestionForm = ({
 
   useEffect(
     () => {
-      // Used local constant
-      // but the values may be passed directly with the || ?
+      // the undefined check is probably no longer needed
+      // but an extra check, in this type of app, are never a negative thing?
       const startLinesSelection = linesSelection ? linesSelection[0] || 0 : 0;
       const endLinesSelection = linesSelection ? linesSelection[1] || 0 : 0;
 

--- a/packages/web/components/QuestionForm.tsx
+++ b/packages/web/components/QuestionForm.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useEffect } from "react";
 
 import { CreateCodeReviewQuestionComponent } from "./apollo-components";
 import { useInputValue } from "../utils/useInputValue";
@@ -8,6 +9,7 @@ export interface QuestionFormProps {
   path?: string;
   postId: string;
   programmingLanguage?: string;
+  linesSelection: number[];
 }
 
 export const QuestionForm = ({
@@ -15,10 +17,24 @@ export const QuestionForm = ({
   path,
   postId,
   programmingLanguage,
+  linesSelection,
 }: QuestionFormProps) => {
-  const [startingLineNum, startingLineNumChange] = useInputValue("0");
-  const [endingLineNum, endingLineNumChange] = useInputValue("0");
+  const [startingLineNum, setStartingLineNum] = useInputValue("0");
+  const [endingLineNum, setEndingLineNum] = useInputValue("0");
   const [text, textChange] = useInputValue("");
+
+  useEffect(
+    () => {
+      // Used local constant
+      // but the values may be passed directly with the || ?
+      const startLinesSelection = linesSelection[0] || 0;
+      const endLinesSelection = linesSelection[1] || 0;
+
+      setStartingLineNum(startLinesSelection);
+      setEndingLineNum(endLinesSelection);
+    },
+    [linesSelection]
+  );
 
   return (
     <CreateCodeReviewQuestionComponent>
@@ -47,20 +63,20 @@ export const QuestionForm = ({
               },
             });
 
-            console.log(response);
+            //console.log(response);
           }}
         >
           <input
             name="startingLineNum"
             placeholder="startingLineNum"
             value={startingLineNum}
-            onChange={startingLineNumChange}
+            onChange={setStartingLineNum}
           />
           <input
             name="endingLineNum"
             placeholder="endingLineNum"
             value={endingLineNum}
-            onChange={endingLineNumChange}
+            onChange={setEndingLineNum}
           />
           <input
             name="question"

--- a/packages/web/components/QuestionSection.tsx
+++ b/packages/web/components/QuestionSection.tsx
@@ -5,10 +5,14 @@ import {
 } from "./apollo-components";
 import { QuestionForm, QuestionFormProps } from "./QuestionForm";
 import { Question } from "./Question";
+import { ChangeEvent } from "react";
 
 interface Props extends QuestionFormProps {
   variables: FindCodeReviewQuestionsVariables;
-  linesSelection: number[];
+  startLinesSelection: number;
+  endLinesSelection: number;
+  handleStartLinesSelection: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleEndLinesSelection: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const QuestionSection = ({
@@ -17,7 +21,10 @@ export const QuestionSection = ({
   postId,
   path,
   programmingLanguage,
-  linesSelection,
+  startLinesSelection,
+  endLinesSelection,
+  handleStartLinesSelection,
+  handleEndLinesSelection,
 }: Props) => {
   return (
     <FindCodeReviewQuestionsComponent variables={variables}>
@@ -33,7 +40,10 @@ export const QuestionSection = ({
               postId={postId}
               path={path}
               programmingLanguage={programmingLanguage}
-              linesSelection={linesSelection}
+              startLinesSelection={startLinesSelection}
+              endLinesSelection={endLinesSelection}
+              handleStartLinesSelection={handleStartLinesSelection}
+              handleEndLinesSelection={handleEndLinesSelection}
             />
             <div>
               {data.findCodeReviewQuestions.map(crq => (

--- a/packages/web/components/QuestionSection.tsx
+++ b/packages/web/components/QuestionSection.tsx
@@ -8,6 +8,7 @@ import { Question } from "./Question";
 
 interface Props extends QuestionFormProps {
   variables: FindCodeReviewQuestionsVariables;
+  linesSelection: number[];
 }
 
 export const QuestionSection = ({
@@ -16,6 +17,7 @@ export const QuestionSection = ({
   postId,
   path,
   programmingLanguage,
+  linesSelection,
 }: Props) => {
   return (
     <FindCodeReviewQuestionsComponent variables={variables}>
@@ -31,6 +33,7 @@ export const QuestionSection = ({
               postId={postId}
               path={path}
               programmingLanguage={programmingLanguage}
+              linesSelection={linesSelection}
             />
             <div>
               {data.findCodeReviewQuestions.map(crq => (

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,7 @@
     "prism-react-renderer": "0.1.5",
     "react": "16.7.0-alpha.2",
     "react-apollo": "2.3.3",
+    "react-debounce-input": "3.2.0",
     "react-dom": "16.7.0-alpha.2",
     "styled-components": "4.1.3"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,6 +27,7 @@
     "next": "7.0.2",
     "next-routes": "1.4.2",
     "prismjs": "1.15.0",
+    "prism-react-renderer": "0.1.5",
     "react": "16.7.0-alpha.2",
     "react-apollo": "2.3.3",
     "react-dom": "16.7.0-alpha.2",

--- a/packages/web/types/prism-react-renderer.ts
+++ b/packages/web/types/prism-react-renderer.ts
@@ -1,1 +1,193 @@
-declare module "prism-react-renderer";
+declare module "prism-react-renderer" {
+  import * as React from "react";
+
+  type Language =
+    | "markup"
+    | "bash"
+    | "clike"
+    | "c"
+    | "cpp"
+    | "css"
+    | "javascript"
+    | "jsx"
+    | "coffeescript"
+    | "actionscript"
+    | "css-extr"
+    | "diff"
+    | "docker"
+    | "elixir"
+    | "erlang"
+    | "git"
+    | "go"
+    | "graphql"
+    | "handlebars"
+    | "haskell"
+    | "java"
+    | "json"
+    | "latex"
+    | "less"
+    | "makefile"
+    | "markdown"
+    | "objectivec"
+    | "ocaml"
+    | "php"
+    | "php-extr"
+    | "python"
+    | "reason"
+    | "ruby"
+    | "rust"
+    | "sass"
+    | "scss"
+    | "sql"
+    | "stylus"
+    | "swift"
+    | "typescript"
+    | "vim"
+    | "yaml";
+
+  type PrismGrammar = {
+    [key: string]: any;
+  };
+
+  type LanguageDict = { [lang in Language]: PrismGrammar };
+
+  type PrismLib = {
+    languages: LanguageDict;
+    tokenize: (
+      code: string,
+      grammar: PrismGrammar,
+      language: Language
+    ) => PrismToken[] | string[];
+    highlight: (
+      code: string,
+      grammar: PrismGrammar,
+      language: Language
+    ) => string;
+  };
+
+  type PrismThemeEntry = {
+    color?: string;
+    backgroundColor?: string;
+    fontStyle?: "normal" | "italic";
+    fontWeight?:
+      | "normal"
+      | "bold"
+      | "100"
+      | "200"
+      | "300"
+      | "400"
+      | "500"
+      | "600"
+      | "700"
+      | "800"
+      | "900";
+    textDecorationLine?:
+      | "none"
+      | "underline"
+      | "line-through"
+      | "underline line-through";
+    opacity?: number;
+    [styleKey: string]: string | number | void;
+  };
+
+  type PrismTheme = {
+    plain: PrismThemeEntry;
+    styles: Array<{
+      types: string[];
+      style: PrismThemeEntry;
+      languages?: Language[];
+    }>;
+  };
+
+  type ThemeDict = {
+    root: StyleObj;
+    plain: StyleObj;
+    [type: string]: StyleObj;
+  };
+
+  type Token = {
+    types: string[];
+    content: string;
+    empty?: boolean;
+  };
+
+  type PrismToken = {
+    type: string;
+    content: Array<PrismToken | string> | string;
+  };
+
+  type StyleObj = {
+    [key: string]: string | number | null;
+  };
+
+  type LineInputProps = {
+    key?: React.Key;
+    style?: StyleObj;
+    className?: string;
+    line: Token[];
+    [otherProp: string]: any;
+  };
+
+  type LineOutputProps = {
+    key?: React.Key;
+    style?: StyleObj;
+    className: string;
+    [otherProps: string]: any;
+  };
+
+  type TokenInputProps = {
+    key?: React.Key;
+    style?: StyleObj;
+    className?: string;
+    token: Token;
+    [otherProp: string]: any;
+  };
+
+  type TokenOutputProps = {
+    key?: React.Key;
+    style?: StyleObj;
+    className: string;
+    children: string;
+    [otherProp: string]: any;
+  };
+
+  type RenderProps = {
+    tokens: Token[][];
+    className: string;
+    style: StyleObj;
+    getLineProps: (input: LineInputProps) => LineOutputProps;
+    getTokenProps: (input: TokenInputProps) => TokenOutputProps;
+  };
+
+  type DefaultProps = {
+    Prism: PrismLib;
+    theme: PrismTheme;
+  };
+
+  interface HighlightProps {
+    Prism: PrismLib;
+    theme?: PrismTheme;
+    language: Language;
+    code: string;
+    children: (props: RenderProps) => React.ReactNode;
+  }
+
+  export default class Highlight extends React.Component<HighlightProps> {
+    themeDict: ThemeDict;
+    getLineProps: (lineInputProps: LineInputProps) => LineOutputProps;
+    getStyleForToken: (token: Token) => { [inlineStyle: string]: string };
+    getTokenProps: (tokenInputPropsL: TokenInputProps) => TokenOutputProps;
+  }
+
+  export const defaultProps: DefaultProps;
+
+  export const Prism: PrismLib;
+
+  export { Language, DefaultProps, PrismTheme };
+}
+
+declare module "prism-react-renderer/themes/*" {
+  import { PrismTheme } from "prism-react-renderer";
+  const theme: PrismTheme;
+  export default theme;
+}

--- a/packages/web/utils/useInputValue.ts
+++ b/packages/web/utils/useInputValue.ts
@@ -3,7 +3,16 @@ import { useState, useCallback } from "react";
 export function useInputValue<T>(initialValue: T): [T, (e: any) => void] {
   const [value, setValue] = useState<T>(initialValue);
   const onChange = useCallback(event => {
-    setValue(event.currentTarget.value);
+    // TODO: needs heavy refactoring
+    // dealing with numbers and events as one...
+    // it works but it is a bad pattern and ugly code
+    if (typeof event == "number") {
+      // maybe event.toString.
+      // It works without it as the input must be converting it?
+      setValue(event);
+    } else {
+      setValue(event.currentTarget.value);
+    }
   }, []);
 
   return [value, onChange];

--- a/packages/web/utils/useInputValue.ts
+++ b/packages/web/utils/useInputValue.ts
@@ -6,13 +6,31 @@ export function useInputValue<T>(initialValue: T): [T, (e: any) => void] {
     // TODO: needs heavy refactoring
     // dealing with numbers and events as one...
     // it works but it is a bad pattern and ugly code
+
+    /*
+     * Probably best to use an object in the args
+     * arg: {
+     *   eventType: string // can be "number" or "MouseEvent"
+     *   eventMouse: MouseEvent
+     *   eventNumber: Number
+     * }
+     * Then we can just have a condition to check the eventType
+     * and setValue appropriately
+     *
+     * This would be more complex but it would "save" the type system
+     *
+     *  */
+
+    let tempValue: any = null;
     if (typeof event == "number") {
       // maybe event.toString.
-      // It works without it as the input must be converting it?
-      setValue(event);
+      // It works without it as the input element must be converting it?
+      tempValue = event;
     } else {
-      setValue(event.currentTarget.value);
+      tempValue = event.currentTarget.value;
     }
+    // react hooks outside of conditions?
+    setValue(tempValue);
   }, []);
 
   return [value, onChange];

--- a/packages/web/utils/useInputValue.ts
+++ b/packages/web/utils/useInputValue.ts
@@ -3,34 +3,7 @@ import { useState, useCallback } from "react";
 export function useInputValue<T>(initialValue: T): [T, (e: any) => void] {
   const [value, setValue] = useState<T>(initialValue);
   const onChange = useCallback(event => {
-    // TODO: needs heavy refactoring
-    // dealing with numbers and events as one...
-    // it works but it is a bad pattern and ugly code
-
-    /*
-     * Probably best to use an object in the args
-     * arg: {
-     *   eventType: string // can be "number" or "MouseEvent"
-     *   eventMouse: MouseEvent
-     *   eventNumber: Number
-     * }
-     * Then we can just have a condition to check the eventType
-     * and setValue appropriately
-     *
-     * This would be more complex but it would "save" the type system
-     *
-     *  */
-
-    let tempValue: any = null;
-    if (typeof event == "number") {
-      // maybe event.toString.
-      // It works without it as the input element must be converting it?
-      tempValue = event;
-    } else {
-      tempValue = event.currentTarget.value;
-    }
-    // react hooks outside of conditions?
-    setValue(tempValue);
+    setValue(event.currentTarget.value);
   }, []);
 
   return [value, onChange];


### PR DESCRIPTION
Added https://github.com/FormidableLabs/prism-react-renderer#prism.
The code already has the line numbers and it is easy to add the event listener, the react way.

Also added the types for the package, taken from a recent PR that wasn't accepted yet.
https://github.com/FormidableLabs/prism-react-renderer/pull/23

It needs some theme attention. The themes from Prism React Renderer are different from the original Prism. So i disabled them (there is still a comment showing how to add them) and used the Prism-coy 
 theme as you decided before. But unfortunately the html structure is a little different and it isn't applying correctly. Also, i think that many of the styles from the original Prism must be done through javascript on the client, which complicate things if one want them to be exactly the same.


To see the differences, here is some examples:
From Prism:
```Javascript
<pre data-src="prism.js" class=" language-javascript" data-src-loaded="">
    <code class=" language-javascript">
        <span class="token keyword">var</span>
        <span class="token operator">=</span> 
        <span class="token punctuation">(</span>
    </code>
</pre>
```
From Prism React Renderer:
```Javascript
<pre data-src="prism.js" class=" language-javascript" data-src-loaded="">
    <code class=" language-javascript">        
        <div class="token-line">
            <span class="CodeFile__LineNo-sc-1desyr9-1 eaHJCX">1</span><!-- the line numbers -->
            <span class="token punctuation">{</span>
            <span class="token plain"></span>
        </div>
        <div class="token-line">
            <span class="CodeFile__LineNo-sc-1desyr9-1 eaHJCX">2</span> <!-- the line numbers -->
            <span class="token punctuation">{</span>
            <span class="token plain"></span>
        </div>
    </code>
</pre>
```

~~For this and for simplicity sake and also to follow your lead and some of the Prism React author, i tried to use Styled Components to do some corrections, but i think i made some mistake. The styles don't seem to be passed correctly. I left them all the same.~~
I was a small typo :( 
All working now.

When i added this commit i forgot to redo the line highlight from the inputs. Just added commit "Added highlight using Styled Components" to correct it.

It should be improved further, since the client browser must be refreshed to see the results.

One more TODO: i forgot to change the highlight color to one more kind to the eyes. I used this one at random just to contrast  when developing.