### PR TITLE
conflict between different @types/graphql versions

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,6 @@
     "@types/cors": "2.8.4",
     "@types/express": "4.16.0",
     "@types/express-session": "1.15.11",
-    "@types/graphql": "14.0.4",
     "@types/ioredis": "4.0.4",
     "@types/node": "10.12.18",
     "@types/passport-github": "1.1.3",

--- a/packages/web/components/CodeFile.tsx
+++ b/packages/web/components/CodeFile.tsx
@@ -14,7 +14,7 @@ import {
 import { filenameToLang } from "../utils/filenameToLang";
 import { loadLanguage } from "../utils/loadLanguage";
 import { CreateQuestion, QuestionProps } from "./QuestionForm";
-import { CreateQuestionReply, QuestionReply } from "./QuestionReply";
+import { CreateQuestionReply } from "./QuestionReply";
 
 interface Props {
   code: string | null;
@@ -49,7 +49,7 @@ const SelectLines = (prop: FindCodeReviewQuestionsQuery) => {
  * TODO: Perhaps refactor SelectLinesMouse as a 'sub function' of SelectLines?
  * Or the two in a more general utils?
  */
-const SelectLinesMouse = (arg: number[]) => {
+/* const SelectLinesMouse = (arg: number[]) => {
   // establishing defaults
   // The lenght of the args array can be variable
   const startLine = arg[0] || 0;
@@ -63,7 +63,7 @@ const SelectLinesMouse = (arg: number[]) => {
   return css`
     ${styles}
   `;
-};
+}; */
 
 interface Comments {
   [key: number]: CommentProps[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,11 +2890,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/graphql@14.0.4":
-  version "14.0.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.4.tgz#d71a75967cd93c33eaea32b626b362ce0f2b2ae9"
-  integrity sha512-gI98ANelzzpq7lZzuYCUJg8LZDjQc7ekj7cxoWt8RezOKaVaAyK27U6AHa9LEqikP1NUhyi8blQQkHYHVRZ7Tg==
-
 "@types/graphql@^14.0.2":
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.3.tgz#389e2e5b83ecdb376d9f98fae2094297bc112c1c"


### PR DESCRIPTION
After 'yarn' in the root, in packages/server/src/index.ts#L34 when creating the ApolloServer, i am getting:
```
Type 'import("node_modules/type-graphql/node_modules/@types/graphql/type/schema").GraphQLSchema' is not assignable to type 'import("node_modules/@types/graphql/type/schema").GraphQLSchema'.
```
There are 2 different installed versions of @types/graphql:

- node_modules\type-graphql\package.json has "@types/graphql": "^14.0.2" and 
- packages\server\package.json has "@types/graphql": "14.0.4"

It also gives an error when starting the GraphQl server.
The error disappeared after deleting the 2º instance. The types seem to be working properly after that.
Shouldn't "@types/graphql" from type-graphql be in devDependencies?

I also deleted an import and commented a function that was no longer used in packages\web\components\CodeFile.tsx
