### PR TITLE
Use Promise.all() in userLoader

### DIFF
--- a/packages/server/src/loaders/userLoader.ts
+++ b/packages/server/src/loaders/userLoader.ts
@@ -2,7 +2,7 @@ import * as DataLoader from "dataloader";
 import { User } from "../entity/User";
 
 export const userLoader = () =>
-  new DataLoader(async (keys: string[]) => {
+  new DataLoader((keys: string[]) => {
     return Promise.all(
       keys.map(id => {
         return User.find({ where: { id } });

--- a/packages/server/src/loaders/userLoader.ts
+++ b/packages/server/src/loaders/userLoader.ts
@@ -3,14 +3,9 @@ import { User } from "../entity/User";
 
 export const userLoader = () =>
   new DataLoader(async (keys: string[]) => {
-    const users = await User.findByIds(keys);
-
-    const userMap: { [key: string]: User } = {};
-
-    users.forEach(u => {
-      userMap[u.id] = u;
-    });
-
-    // O(n) * O(1)
-    return keys.map(k => userMap[k]);
+    return Promise.all(
+      keys.map(id => {
+        return User.find({ where: { id } });
+      })
+    );
   });


### PR DESCRIPTION
I've made some tests and apparently, the order of the array items is kept the same after running `Promise.all`, even if they are resolved in different orders, as you can see in the appended screenshot.

I also think that using `Promise.all` is more performatic than using  `forEach` and `map` (please correct me if I'm wrong).

<details>
  <summary>Screenshot</summary>
  <img src="https://user-images.githubusercontent.com/23662020/51767547-e3db7500-20c4-11e9-80c3-c21f4783d66f.png" alt="example" />
</details>