### PR TITLE
Fix ▾button not rotating up when discussion is open

### DIFF
--- a/packages/ui/src/components/CodeCard/index.tsx
+++ b/packages/ui/src/components/CodeCard/index.tsx
@@ -113,6 +113,7 @@ const Pre = styled.pre`
     background-color: transparent;
     color: ${p => p.theme.colors.primary[2]};
     cursor: pointer;
+    display: flex;
     width: 36px;
     height: 22px;
     line-height: 1;
@@ -127,7 +128,6 @@ const Pre = styled.pre`
     & .badge-counter {
       background-color: ${p => p.theme.colors.primary[3]};
       border-radius: 50%;
-      display: inline-block;
       font-size: 10px;
       margin: 0;
       padding: 5.5px 0;
@@ -136,7 +136,6 @@ const Pre = styled.pre`
     }
 
     & .badge-icon {
-      display: inline;
       font-size: 20px;
       vertical-align: middle;
       transition: transform 0.3s ease-in-out;

--- a/packages/web/components/CommentForm.tsx
+++ b/packages/web/components/CommentForm.tsx
@@ -52,7 +52,7 @@ const FormContainer = styled.div`
   background-color: #ffffff;
   border-top: ${(p: { isReply: boolean; view: string }) =>
     p.isReply ? "none" : "1px solid #d1d5da"};
-  border-bottom: ${p => (p.view ? "none" : "1px solid #d1d5da")};
+  border-bottom: ${p => (p.view == "repo-view" ? "none" : "1px solid #d1d5da")};
   display: flex;
   flex-direction: column;
   padding: ${(p: { isReply: boolean }) => (p.isReply ? "0" : "0.9rem")};

--- a/packages/web/components/Discussion.tsx
+++ b/packages/web/components/Discussion.tsx
@@ -60,7 +60,7 @@ export const CodeDiscussionView: React.FC<CodeDiscussionViewProps> = ({
   const [showDiscussion, setShowDiscussion] = useState(false);
 
   const onToggleDiscussion = useCallback(
-    ({ target: elm }: any = {}) => {
+    ({ currentTarget: elm }: any = {}) => {
       elm && elm.classList.toggle("is-open");
       if (showDiscussion) {
         newQuestionRef.current = false;
@@ -80,7 +80,7 @@ export const CodeDiscussionView: React.FC<CodeDiscussionViewProps> = ({
   useEffect(() => {
     if (comments.length == 1 && comments[0].newComment) {
       newQuestionRef.current = true;
-      onToggleDiscussion({ target: toggleButtonRef.current });
+      onToggleDiscussion({ currentTarget: toggleButtonRef.current });
     }
   }, []);
 


### PR DESCRIPTION
The issue caused by different in event.target between Chrome and Firefox