### PR TITLE
Fix unified plugins import

### DIFF
--- a/packages/server/src/modules/comment/resolver.ts
+++ b/packages/server/src/modules/comment/resolver.ts
@@ -1,7 +1,7 @@
-import rehypeStringify from "rehype-stringify";
-import remarkParse from "remark-parse";
-import remarkPing from "remark-ping";
-import remark2rehype from "remark-rehype";
+import * as rehypeStringify from "rehype-stringify";
+import * as remarkParse from "remark-parse";
+import * as remarkPing from "remark-ping";
+import * as remark2rehype from "remark-rehype";
 import { Arg, Ctx, Mutation, Resolver, UseMiddleware } from "type-graphql";
 import { In, Repository } from "typeorm";
 import { InjectRepository } from "typeorm-typedi-extensions";
@@ -53,18 +53,20 @@ export class CommentResolver {
 
     unified()
       .use(remarkParse)
-      .use(remarkPing, { pingUsername: true, userURL: () => "" })
+      .use(remarkPing, { pingUsername: () => true, userURL: () => "" })
       .use(remark2rehype)
       .use(rehypeStringify)
       .process(input.text)
-      .then(async (vfile: any) => {
-        if (!vfile.data.ping.length) {
+      .then(async vfile => {
+        // data property type is set unknown
+        const { ping } = vfile.data as { ping: string[] };
+        if (!Array.isArray(ping) || !ping.length) {
           return;
         }
 
         const users = await this.userRepo.find({
           // you can mention up to 10 people per comment
-          username: In(vfile.data.ping.slice(0, 10)),
+          username: In(ping.slice(0, 10)),
         });
 
         if (users.length) {


### PR DESCRIPTION
The cause for #288 was improper import.

rehype-stringify, remark-parse, remark-ping, remark-rehype are commonjs modules without default name to import.

> In 2019, one of the things I’m going to do is stop exporting things as default from my CommonJS/ES6 modules.
> Importing a default export has grown to feel like a guessing game where I have a 50/50 chance of being wrong each time. Is it a class? Is it a function?
> — Nicholas C. Zakas [January 12, 2019](https://twitter.com/slicknet/status/1084101377297506304?ref_src=twsrc%5Etfw)

> Why I've stopped exporting defaults from my JavaScript modules
> — Nicholas C. Zakas [January 15, 2019](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/)

